### PR TITLE
Minor corrections of Eclipse New and Noteworthy

### DIFF
--- a/4.24/platform.html
+++ b/4.24/platform.html
@@ -46,16 +46,16 @@ ul {padding-left: 13px;}
   </tr>
   
     <tr id="welcomescreen"> <!-- https://bugs.eclipse.org/bugs/show_bug.cgi?id=579463 -->
-    <td class="title"><a href="#welcomescreen">Welcome screen not changing the visibily to the toolbars anymore</a></td>
+    <td class="title"><a href="#welcomescreen">Welcome screen not changing the visibility of the toolbars anymore</a></td>
     <td class="content">
- 	  The welcome screen will not hide the toolbars anymore in its maximized state to behave similar to a regular view. 
+ 	  The welcome screen will not hide the toolbars anymore in its maximized state to behave similar like a regular view. 
     </td>
   </tr>
   
   <tr id="quickaccess-filesystem"> <!-- https://bugs.eclipse.org/bugs/show_bug.cgi?id=576341 -->
     <td class="title"><a href="#codeassist-module">Find Actions can open files from file system</a></td>
     <td class="content">
-      The <em>Find Actions</em> command, usually accessible with <code>Ctrl+3</code>, now allows to open
+      The <em>Find Actions</em> command, usually accessible with <b>Ctrl+3</b>, now allows to open
       a file if the query is the path of an existing file on the filesystem.
     </td>
   </tr>
@@ -76,17 +76,17 @@ ul {padding-left: 13px;}
       keys have been assigned yet (suggestions below), but can be assigned via Window/Preferences/Keys:
       <dl>
         <dt><b>Multi selection down relative to anchor selection</b></dt>
-          <dd>Search next matching region and add it to the current selection, or remove first element from current multi-selection (e.g. Ctrl-Alt-J)</dd>
+          <dd>Search next matching region and add it to the current selection, or remove first element from current multi-selection (e.g. <b>Ctrl-Alt-J</b>).</dd>
         <dt><b>Multi selection up relative to anchor selection</b></dt>
-          <dd>Search next matching region above and add it to the current selection, or remove last element from current multi-selection  (e.g. Alt-J)</dd>
+          <dd>Search next matching region above and add it to the current selection, or remove last element from current multi-selection  (e.g. <b>Alt-J</b>).</dd>
         <dt><b>End multi-selection</b></dt>
-          <dd>Unselects all multi-selections returning to a single cursor (e.g. ESC)</dd>
+          <dd>Unselects all multi-selections returning to a single cursor (e.g. <b>Esc</b>)</dd>
         <dt><b>Add all matches to multi-selection</b></dt>
-          <dd>Looks for all regions matching the current selection or identifier and adds them to a multi-selection (e.g. Ctrl-Shift-Alt-J)</dd>
-        <dt><b>Multi caret up (e.g. Ctrl-Alt-Shift-Up)</b></dt>
-          <dd>Add a new caret/multi selection above the current line, or remove the last caret/multi selection</dd>
-        <dt><b>Multi caret down (e.g. Ctrl-Alt-Shift-Down)</b></dt>
-          <dd>Add a new caret/multi selection below the current line, or remove the first caret/multi selection</dd>  
+          <dd>Looks for all regions matching the current selection or identifier and adds them to a multi-selection (e.g. <b>Ctrl-Shift-Alt-J</b>).</dd>
+        <dt><b>Multi caret up</b></dt>
+          <dd>Add a new caret/multi selection above the current line, or remove the last caret/multi selection (e.g. <b>Ctrl-Alt-Shift-Up</b>).</dd>
+        <dt><b>Multi caret down</b></dt>
+          <dd>Add a new caret/multi selection below the current line, or remove the first caret/multi selection (e.g. <b>Ctrl-Alt-Shift-Down</b>).</dd>  
       </dl>
       Besides that the display of multiple carets on the Windows platform has been improved to provide a
       more stable user experience.<br/><br/>


### PR DESCRIPTION
* use consistent formatting for keys
* move shortcuts, so they are all part of text, not mixed in text and
headline