### PR TITLE
Display info and link to release notes

### DIFF
--- a/4.21/index.html
+++ b/4.21/index.html
@@ -19,11 +19,9 @@
     The Eclipse installer and other packages can be downloaded from the <a href="https://www.eclipse.org/downloads/packages/installer">Eclipse Installer</a> page.
   </p>
   
-  <!--
   <p>
   	The 4.21 release notes for the Eclipse SDK project can be found <a href="https://www.eclipse.org/eclipse/development/readme_eclipse_4.21.php">here</a>.
   </p>
-  -->
   
   <p>Here are some of the more noteworthy items available in this release.</p>
 

--- a/4.22/index.html
+++ b/4.22/index.html
@@ -19,11 +19,9 @@
     The Eclipse installer and other packages can be downloaded from the <a href="https://www.eclipse.org/downloads/packages/installer">Eclipse Installer</a> page.
   </p>
   
-  <!--
   <p>
   	The 4.22 release notes for the Eclipse SDK project can be found <a href="https://www.eclipse.org/eclipse/development/readme_eclipse_4.22.php">here</a>.
   </p>
-  -->
   
   <p>Here are some of the more noteworthy items available in this release.</p>
 

--- a/4.23/index.html
+++ b/4.23/index.html
@@ -19,11 +19,9 @@
     The Eclipse installer and other packages can be downloaded from the <a href="https://www.eclipse.org/downloads/packages/installer">Eclipse Installer</a> page.
   </p>
   
-  <!--
   <p>
   	The 4.23 release notes for the Eclipse SDK project can be found <a href="https://www.eclipse.org/eclipse/development/readme_eclipse_4.23.php">here</a>.
   </p>
-  -->
   
   <p>Here are some of the more noteworthy items available in this release.</p>
 


### PR DESCRIPTION
Since 4.21 the paragraph on release notes has been commented out.

Up until 4.20 these links got enabled late in the development cycle, like commit 1d89fcbd08aba2f0e1b01c9a886e3094270fdc86
for [Bug 573744](https://bugs.eclipse.org/bugs/show_bug.cgi?id=573744)

cc: @lshanmug as I know you used to take care of it until 4.20. AFAICT there was no bug like [Bug 573744](https://bugs.eclipse.org/bugs/show_bug.cgi?id=573744) for 4.21 onwards