### PR TITLE
Fix text flow

### DIFF
--- a/4.25/platform.html
+++ b/4.25/platform.html
@@ -49,6 +49,7 @@ ul {padding-left: 13px;}
     <td class="content">
 		Multiple dialogs have been updated to not contain a help icon if they ask the user for a decision to align with the UI guidelines existing for the operating systems.
 		For example, if you close an edited file, the resulting dialog will not show a help icon anymore.
+		<p/>
       	<img  src="images/save-resource-dialog.png" alt="" />
     </td>
   </tr>


### PR DESCRIPTION
Previously the text and the image were layout using a continuous flow,
i.e. the image was _right of_ the last words.

![image](https://user-images.githubusercontent.com/406876/174401120-f118600f-4c27-4ccc-bf56-6491e3a0f4ca.png)

Make the image appear below the text, with some space by an empty
paragraph.