### PR TITLE
Move N&N about slf4j migration to Maven-Central to platform_isv

### DIFF
--- a/4.26/platform.html
+++ b/4.26/platform.html
@@ -75,28 +75,6 @@ ul {padding-left: 13px;}
     <h2>General Updates </h2>
     </td>
   </tr>
-    <tr id="slf4j">
-    <!-- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/588 -->
-    <td class="title">Migration to SLF4J 1.7.36 from Maven-Central</td>
-    <td class="content">
-      <p>
-      The Eclipse Platform migrated to the SLF4J artifacts from Maven-Central in version 1.7.36.
-      With this migration the <code>Bundle-SymbolicName</code> changed from <code>org.slf4j.api</code> to <code>slf4j.api</code>.
-      </p>
-      <p>
-      Furthermore the way how a SLF4J-binding Plugin is wired to the slf4j-api Plugin has changed.
-      Previously with the artifacts provided by Eclipse Orbit, each binding had a separate fragment whose host was the <code>org.slf4j.api</code> Plugin and that required the binding Plugin.
-      The <code>slf4j.api</code> Plugin from Maven-Central instead imports the package <code>org.slf4j.impl</code>, which is exported by each binding Plugin.
-      Consequently, unlike before, <code>slf4j.api</code> does not resolve if no binding is present.
-      If you want to disable logging with slf4j, you can add the <code>slf4j-nop</code> binding to your application or product.
-      </p>
-      <p>
-      Additionally the <code>slf4j.api</code> Plugin as well as <code>org.apache.commons.logging</code> have been removed from all Features of the Eclipse Platform to enable Application/Product builders to freely choose the logging-framework and bridging strategy eventually used in their product.
-      If nothing is chosen explicitly P2 assembles a minimal result depending on the available Plugins.
-      </p>
-    </td>
-  </tr>
-  
   <!-- ******************* End of General Updates ************************************* -->
   <tr><td colspan="2"/></tr>
 </tbody>

--- a/4.26/platform_isv.html
+++ b/4.26/platform_isv.html
@@ -168,6 +168,37 @@ Clients may have relied on the old implementation which called done() in the UI 
     </td>
   </tr>
   <!-- *********************** End of SWT *********************** -->
+
+  <!-- ******************* General Updates ************************************* -->
+  <tr>
+    <td id="GeneralUpdates" class="section" colspan="2">
+    <h2>General Updates </h2>
+    </td>
+  </tr>
+    <tr id="slf4j">
+    <!-- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/588 -->
+    <td class="title">Migration to SLF4J 1.7.36 from Maven-Central</td>
+    <td class="content">
+      <p>
+      The Eclipse Platform migrated to the SLF4J artifacts from Maven-Central in version 1.7.36.
+      With this migration the <code>Bundle-SymbolicName</code> changed from <code>org.slf4j.api</code> to <code>slf4j.api</code>.
+      </p>
+      <p>
+      Furthermore the way how a SLF4J-binding Plugin is wired to the slf4j-api Plugin has changed.
+      Previously with the artifacts provided by Eclipse Orbit, each binding had a separate fragment whose host was the <code>org.slf4j.api</code> Plugin and that required the binding Plugin.
+      The <code>slf4j.api</code> Plugin from Maven-Central instead imports the package <code>org.slf4j.impl</code>, which is exported by each binding Plugin.
+      Consequently, unlike before, <code>slf4j.api</code> does not resolve if no binding is present.
+      If you want to disable logging with slf4j, you can add the <code>slf4j-nop</code> binding to your application or product.
+      </p>
+      <p>
+      Additionally the <code>slf4j.api</code> Plugin as well as <code>org.apache.commons.logging</code> have been removed from all Features of the Eclipse Platform to enable Application/Product builders to freely choose the logging-framework and bridging strategy eventually used in their product.
+      If nothing is chosen explicitly P2 assembles a minimal result depending on the available Plugins.
+      </p>
+    </td>
+  </tr>
+  
+  <!-- ******************* End of General Updates ************************************* -->
+
   <tr><td colspan="2"/></tr>
 </tbody>
 </table>


### PR DESCRIPTION
Entry for
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/588

Moving as suggested in https://github.com/eclipse-platform/www.eclipse.org-eclipse-news/pull/70#issuecomment-1325986605