### PR TITLE
Correctly vertical align first paragraphs, fixes #82

### DIFF
--- a/4.27/news.css
+++ b/4.27/news.css
@@ -53,6 +53,10 @@ p {
   margin: 1em 0; /* undo styles.min.css */
 }
 
+td p:first-of-type {
+  margin-top: 0; /* margin top of news entries must be zero, otherwise paragraphs start lower than their corresponding headline */
+}
+
 table.news td {
   padding: 10px; /* undo styles.min.css */
   border-top: solid thin black;


### PR DESCRIPTION
Get rid of the top margin of each first paragraph of news entries, it makes the text not be aligned correctly with the headline next to it.